### PR TITLE
Fixed elf/ directory doesn't exist when `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ check: $(BIN) $(TEST_OBJ)
 	@$(ARM_EXEC) ./amacc amacc.c tests/hello.c
 
 $(OBJ_DIR)/amacc: $(BIN)
+	@mkdir -p $(OBJ_DIR)
 	@$(ARM_EXEC) ./$^ -o $(OBJ_DIR)/amacc amacc.c
 
 $(TEST_DIR)/%.o: $(TEST_DIR)/%.c $(BIN) $(OBJ_DIR)/amacc


### PR DESCRIPTION
I've tried to remove my elf/ directory, and `make check` will fail due to `could not open(elf/amacc)`