### PR TITLE
Add python run test script

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import unittest
+import subprocess as sp
+import os
+
+qemuCmd = "qemu-arm -L /usr/arm-linux-gnueabihf".split()
+amacc = "./amacc"
+gcc = "arm-linux-gnueabihf-gcc"
+amaccdir = "amaccelf"
+gccdir = "gccelf"
+
+
+class TestAmacc(unittest.TestCase):
+    pass
+
+
+def testGenerator(f):
+    def test(self):
+        print("verify file: %s" % (f))
+
+        # amaccexe = os.path.join(amaccdir, os.path.splitext(os.path.basename(f))[0])
+        gccexe = os.path.join(gccdir, os.path.splitext(os.path.basename(f))[0])
+        gccparams = [gcc, "-o", gccexe, f]
+        sp.check_call(gccparams)
+
+        amaccout = sp.Popen(qemuCmd + [amacc, f, "2"], stdout=sp.PIPE).communicate()[0]
+        gccout = sp.Popen(qemuCmd + [gccexe, "2"], stdout=sp.PIPE).communicate()[0]
+
+        self.maxDiff = None
+        self.assertEqual(amaccout.decode("utf-8"), gccout.decode("utf-8"))
+
+    return test
+
+if __name__ == '__main__':
+    if not os.access(amaccdir, os.F_OK):
+        os.mkdir(amaccdir)
+    if not os.access(gccdir, os.F_OK):
+        os.mkdir(gccdir)
+
+    for dirpath, _, filenames in os.walk("tests"):
+        for f in filenames:
+            testfile = os.path.abspath(os.path.join(dirpath, f))
+            test_func = testGenerator(testfile)
+            setattr(TestAmacc, 'test_%s' % (f), test_func)
+
+    unittest.main()

--- a/runtest.py
+++ b/runtest.py
@@ -4,6 +4,7 @@
 import unittest
 import subprocess as sp
 import os
+import sys
 
 qemuCmd = "qemu-arm -L /usr/arm-linux-gnueabihf".split()
 amacc = "./amacc"
@@ -39,10 +40,13 @@ if __name__ == '__main__':
     if not os.access(gccdir, os.F_OK):
         os.mkdir(gccdir)
 
+    namePattern = ""
+    if len(sys.argv) > 1:
+        namePattern = sys.argv[1]
+
     for dirpath, _, filenames in os.walk("tests"):
-        for f in filenames:
+        for f in filter(lambda name: namePattern in name, filenames):
             testfile = os.path.abspath(os.path.join(dirpath, f))
             test_func = testGenerator(testfile)
-            setattr(TestAmacc, 'test_%s' % (f), test_func)
-
-    unittest.main()
+            setattr(TestAmacc, 'test_%s' % (os.path.splitext(f)[0]), test_func)
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
Add a python script written in python unittest, which will use `arm-linux-gnueabihf-gcc` as correct answer, and test amacc output result. Using this tool I found three testcase cannot passed: char.c, ptr.c, shift.c
```
Usage: ./runtest.py # test every c files in tests directory
or
Usage: ./runtest.py pattern # test files in tests that file name contains pattern
example: ./runtest.py eq # only run tests/eq.c
```

Currently we cannot test against elf output since subprocess cannot get the output of running elf. The problem may cause by that the elf generated by `amacc` doesn't flush the `stdout` buffer before exit. If running in terminal it will be fine since `libc` set stdout to line buffer if `isatty() == 1`, however it prevent we tests it using python subprocess.





