### PR TITLE
Run main() with __libc_start_main()

### DIFF
--- a/amacc.c
+++ b/amacc.c
@@ -145,7 +145,7 @@ void next()
                 while (*p != 0 && *p != '\n') ++p;
             } else {
                 // Div is not supported
-	        return;
+                return;
             }
             break;
         case '\'':
@@ -287,7 +287,7 @@ void expr(int lev)
         next(); expr(Inc);
         if (ty > INT) ty = ty - PTR;
         else fatal("bad dereference");
-	if (ty <= INT || ty >= PTR) *++e = (ty == CHAR) ? LC : LI;
+        if (ty <= INT || ty >= PTR) *++e = (ty == CHAR) ? LC : LI;
         break;
     case And:
         next(); expr(Inc);
@@ -784,12 +784,13 @@ int *codegen(int *jitmem, int *jitmap, int reloc)
                 tmp = *--il;
                 if ((int) je > tmp + 4096 + 8) die("can't reach the pool");
                 iv--; if (iv[0] == iv[1]) je--;
-                if (tmp & 1)
-                    *(int *) (tmp - 1) = 0xe59ff000 | ((int) je - tmp - 7);
+                if (tmp & 1) {
                     // ldr pc, [pc, #..]
-                else
+                    *(int *) (tmp - 1) = 0xe59ff000 | ((int) je - tmp - 7);
+                } else {
+                    // ldr r0, [pc, #..]
                     *(int *) tmp = 0xe59f0000 | ((int) je - tmp - 8);
-  	            // ldr r0, [pc, #..]
+                }
                 *je++ = *iv;
             }
             if (genpool == 2) { // jump past the pool
@@ -1273,9 +1274,9 @@ int elf32(int poolsz, int *start)
         // movt ip addr_to_got
         *(int *) to = 0xe300c000 | (0xfff & (int) (got_func_slot[i])) |
                       (0xf0000 & ((int) (got_func_slot[i]) << 4));
-	to = to + 4;
+        to = to + 4;
         // movw ip addr_to_got
-  	*(int *) to = 0xe340c000 |
+        *(int *) to = 0xe340c000 |
                       (0xfff & ((int) (got_func_slot[i]) >> 16)) |
                       (0xf0000 & ((int) (got_func_slot[i]) >> 12));
         to = to + 4;

--- a/amacc.c
+++ b/amacc.c
@@ -852,7 +852,7 @@ enum {
     _PROT_EXEC = 4, _PROT_READ = 1, _PROT_WRITE = 2,
     _MAP_PRIVATE = 2, _MAP_ANON = 32
 };
-int jit(int poolsz, int *start, int argc, char **argv)
+int jit(int poolsz, int *main, int argc, char **argv)
 {
     char *jitmem;  // executable memory for JIT-compiled native code
     int *je, *tje, *_start,  retval, *jitmap, *res;
@@ -884,7 +884,7 @@ int jit(int poolsz, int *start, int argc, char **argv)
     if (!(je = codegen(je, jitmap))) return 1;
     if (je >= jitmap) die("jitmem too small");
     *tje = 0xeb000000 |
-           (((jitmap[((int) start - (int) text) >> 2] -
+           (((jitmap[((int) main- (int) text) >> 2] -
               (int) tje - 8) >> 2) &
             0x00ffffff);
 
@@ -1061,7 +1061,7 @@ int append_func_sym(char **data, int name)
 
 enum { ALIGN = 4096 };
 
-int elf32(int poolsz, int *start)
+int elf32(int poolsz, int *main)
 {
     char *o, *buf, *code, *entry, *je, *tje;
     char *to, *phdr, *dseg;
@@ -1370,7 +1370,7 @@ int elf32(int poolsz, int *start)
         return 1;
     if ((int *) je >= jitmap) die("jitmem too small");
     *(int *) tje = 0xeb000000 |
-          (((jitmap[((int) start - (int) text) >> 2] - (int) tje - 8) >> 2) &
+          (((jitmap[((int) main - (int) text) >> 2] - (int) tje - 8) >> 2) &
            0x00ffffff);
     memcpy(code_addr, code,  je - code);
 

--- a/amacc.c
+++ b/amacc.c
@@ -588,7 +588,7 @@ void stmt()
 
 void die(char *msg) { printf("codegen: %s\n", msg); exit(2); }
 
-int *codegen(int *jitmem, int *jitmap, int reloc)
+int *codegen(int *jitmem, int *jitmap)
 {
     int *pc;
     int i, tmp, genpool;
@@ -866,7 +866,7 @@ int jit(int poolsz, int *start, int argc, char **argv)
     *je++ = 0xe5850000;       // str     r0, [r5]
     *je++ = 0xe28dd008;       // add     sp, sp, #8
     *je++ = 0xe8bd9ff0;       // pop     {r4-r12, pc}
-    if (!(je = codegen(je, jitmap, 0))) return 1;
+    if (!(je = codegen(je, jitmap))) return 1;
     if (je >= jitmap) die("jitmem too small");
     *tje = 0xeb000000 |
            (((jitmap[((int) start - (int) text) >> 2] -
@@ -1083,7 +1083,7 @@ int elf32(int poolsz, int *start)
     tmp_code = code;
     jitcode_off = 7;  // 7 instruction (tmp_code)
     tmp_code = tmp_code + jitcode_off * 4;
-    je = (char *) codegen((int *) tmp_code, jitmap, 1);
+    je = (char *) codegen((int *) tmp_code, jitmap);
     if (!je) return 1;
     if ((int*) je >= jitmap) die("jitmem too small");
 
@@ -1332,7 +1332,7 @@ int elf32(int poolsz, int *start)
              tmp_code = tmp_code + 4;  // mov     r7, #1
     *(int *) tmp_code = 0xef000000;
              tmp_code = tmp_code + 4;  // svc 0
-    je = (char *) codegen((int *) tmp_code, jitmap, 1);
+    je = (char *) codegen((int *) tmp_code, jitmap);
     if (!je)
         return 1;
     if ((int *) je >= jitmap) die("jitmem too small");

--- a/amacc.c
+++ b/amacc.c
@@ -1496,13 +1496,13 @@ int main(int argc, char **argv)
           "LI   LC   SI   SC   PSH  "
           "OR   XOR  AND  EQ   NE   LT   GT   LE   GE   "
           "SHL  SHR  ADD  SUB  MUL  "
-          "OPEN READ WRIT CLOS PRTF MALC MSET MCMP MCPY "
-          "DSYM BSCH MMAP CLCA EXIT";
+          "OPEN READ WRIT CLOS PRTF MALC MSET MCMP MCPY MMAP "
+          "DSYM BSCH CLCA EXIT";
 
     p = "break case char default else enum if int return "
         "sizeof struct switch for while "
-        "open read write close printf malloc memset memcmp memcpy mmap dlsym "
-        "bsearch __clear_cache exit void main";
+        "open read write close printf malloc memset memcmp memcpy mmap "
+        "dlsym bsearch __clear_cache exit void main";
 
     i = Break;
     while (i <= While) { // add keywords to symbol table

--- a/amacc.c
+++ b/amacc.c
@@ -77,6 +77,21 @@ enum { CHAR, INT, PTR = 256, PTR2 = 512 };
 // ELF generation
 char **plt_func_addr;
 
+char* append_strtab(char **strtab, char *str)
+{
+    int nbytes;
+    char *res;
+    nbytes = 0;
+    while (str[nbytes] != '\0') {
+        ++nbytes;
+    }
+    ++nbytes;
+    res = *strtab;
+    memcpy(res, str, nbytes);
+    *strtab = res + nbytes;
+    return res;
+}
+
 void next()
 {
     char *pp;
@@ -1174,12 +1189,22 @@ int elf32(int poolsz, int *start)
     // .shstrtab (embedded in PT_LOAD of data)
     shstrtab_addr = data;
     shstrtab_off = (int)(data - pt_dyn) + (int)(dseg - buf);
-    shstrtab_size = 99;
-    memcpy(shstrtab_addr,
-            "\0.shstrtab\0.text\0.data\0.dynamic\0.strtab\0.symtab\0.dynstr"
-            "\0.dynsym\0.interp\0.rel.plt\0.plt\0.got\0.rwdata\0"
-            , shstrtab_size);
-    data = data + shstrtab_size;
+    shstrtab_size = 0;
+    append_strtab(&data, "");
+    append_strtab(&data, ".shstrtab");
+    append_strtab(&data, ".text");
+    append_strtab(&data, ".data");
+    append_strtab(&data, ".dynamic");
+    append_strtab(&data, ".strtab");
+    append_strtab(&data, ".symtab");
+    append_strtab(&data, ".dynstr");
+    append_strtab(&data, ".dynsym");
+    append_strtab(&data, ".interp");
+    append_strtab(&data, ".rel.plt");
+    append_strtab(&data, ".plt");
+    append_strtab(&data, ".got");
+    append_strtab(&data, ".rwdata");
+    shstrtab_size = data - shstrtab_addr;
 
     func_str = "\0open\0read\0write\0close\0"
                "printf\0malloc\0memset\0memcmp\0memcpy\0mmap\0"


### PR DESCRIPTION
In a private conversation, @yodalee mentioned that the compiled executable won't flush the its standard output during its execution if we redirect the output to a file.  It turns out to be a problem of the `_start()` stub. It calls `main()` function directly, thus libc does not have a chance to flush the buffer.

This commit fixes the problem by rewriting the `_start()` stub for `elf32()` function.