### PR TITLE
issue 13: nested for loop broken

### DIFF
--- a/amacc.c
+++ b/amacc.c
@@ -450,7 +450,7 @@ void expr(int lev)
 void stmt()
 {
     int *a, *b, *d;
-    int *x, *y, *z;
+    int *x;
     int i;
 
     switch (tk) {
@@ -529,6 +529,9 @@ void stmt()
         else fatal("semicolon expected");
         return;
     case For:
+        // For loop is implemented as:
+        // Init -> Cond -> Bz to end -> Jmp to Body
+        // After -> Jmp to Cond -> Body -> Jmp to After
         next();
         if (tk == '(') next();
         else fatal("open paren expected");
@@ -539,11 +542,12 @@ void stmt()
         }
         if (tk == ';') next();
         else fatal("semicolon expected");
-        a = e + 1;
+        a = e + 1; // Points to entry of for cond
         expr(Assign);
         if (tk == ';') next();
         else fatal("semicolon expected");
         *++e = BZ; b = ++e;
+        *++e = JMP; d = ++e; // Jump to entry of for loop body
         x = e + 1; // Points to entry of for loop afterthought
         expr(Assign);
         while (tk == ',') {
@@ -552,24 +556,11 @@ void stmt()
         }
         if (tk == ')') next();
         else fatal("close paren expected");
-        y = e + 1; // Points to entry of for loop body
-        stmt();
-        z = e + 1; // Points to entry of jmp command
         *++e = JMP; *++e = (int) a;
+        *d = (int)(e+1); // Modify address of jump
+        stmt();
+        *++e = JMP; *++e = (int) x;
         *b = (int) (e + 1);
-
-        // Swaps body chunk and afterthought chunk
-        //
-        // We parse it as:
-        // Init -> Cond -> Bz -> After -> Body -> Jmp
-        //
-        // But we want it to be:
-        // Init -> Cond -> Bz -> Body -> After -> Jmp
-        memcpy((void *) ((int) e + 4), x, (int) y - (int) x);
-        memcpy(x, y, (int) z - (int) y);
-        memcpy((void *) ((int) x + (int) z - (int) y),
-               (void *) ((int) e + 4), (int)y - (int) x);
-        memset((void *) ((int) e + 4), 0, (int)y - (int) x);
         return;
     case '{':
         next();

--- a/tests/for.c
+++ b/tests/for.c
@@ -2,12 +2,20 @@
 
 int main(int argc, char **argv)
 {
-        int i, j;
+    int i, j;
 
-        j = 10;
+    j = 10;
 
-        for (i = 0, printf("let's loop\n"); i < j; i++, printf("loops again\n"))
-                printf("loop %d\n", i);
+    for (i = 0, printf("let's loop\n"); i < j; i++, printf("loops again\n"))
+        printf("loop %d\n", i);
 
-        return 0;
+    printf("nested loop\n");
+    for (i = 1; i < 10; i++) {
+        for (j = 1; j < 10; j++) {
+            printf("%d * %d = %d\t", i, j, i*j);
+        }
+        printf("\n");
+    }
+
+    return 0;
 }


### PR DESCRIPTION
The for loop in previous version is parsed as:
// Init -> Cond -> Bz -> After -> Body -> Jmp
and then swap the After and Body chunk.
The swap does not consider the jump address in Body chunk and thus the
incorrect jump address causes unexpected behavior. This issue has been
reported at issue #13 

In this patches for loop is parsed as:
Init -> Cond -> Bz to end -> Jmp to Body ->
After -> Jmp to Cond -> Body ->Jmp to After

It disadvantage at generating more Jmp instruction, which may decrease
overall performance. However, it is more convenient then recalculating
all jump address in Body and After chunk.