### PR TITLE
Add -fsigned-char and fix tests/char.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ARM_EXEC = qemu-arm -L /usr/$(shell echo $(CROSS_COMPILE) | sed s'/.$$//')
 all: $(BIN)
 
 amacc: amacc.c
-	$(CROSS_COMPILE)gcc $(CFLAGS) -fsigned-char -o amacc $? -g -ldl
+	$(CROSS_COMPILE)gcc $(CFLAGS) -o amacc $? -g -ldl
 
 check: $(BIN) $(TEST_OBJ)
 	@echo "[ JIT      ]"

--- a/amacc.c
+++ b/amacc.c
@@ -301,9 +301,17 @@ void expr(int lev)
         break;
     case Mul:
         next(); expr(Inc);
-        if (ty > INT) ty = ty - PTR;
+        if (ty >= PTR) ty = ty - PTR;
         else fatal("bad dereference");
-        if (ty <= INT || ty >= PTR) *++e = (ty == CHAR) ? LC : LI;
+        if (ty >= PTR) {
+            *++e = LI;
+        } else if (ty == INT) {
+            *++e = LI;
+        } else if (ty == CHAR) {
+            *++e = LC;
+        } else {
+            fatal("unexpected type");
+        }
         break;
     case And:
         next(); expr(Inc);

--- a/amacc.c
+++ b/amacc.c
@@ -1506,10 +1506,13 @@ int main(int argc, char **argv)
     }
     if (argc > 0 && **argv == '-' && (*argv)[1] == 'o') {
         elf = 1; --argc; ++argv;
+        if (argc < 1) {
+            printf("no output file argument\n"); return -1;
+        }
         if ((elf_fd = open(*argv, _O_CREAT | _O_WRONLY, 0775)) < 0) {
             printf("could not open(%s)\n", *argv); return -1;
         }
-        ++argv;
+        --argc; ++argv;
     }
     if (argc < 1) {
         printf("usage: amacc [-s] [-v] [-o object] file ...\n"); return -1;

--- a/amacc.c
+++ b/amacc.c
@@ -68,8 +68,8 @@ enum {
 enum {
     LEA ,IMM ,JMP ,JSR ,BZ  ,BNZ ,ENT ,ADJ ,LEV ,LI  ,LC  ,SI  ,SC  ,PSH ,
     OR  ,XOR ,AND ,EQ  ,NE  ,LT  ,GT  ,LE  ,GE  ,SHL ,SHR ,ADD ,SUB ,MUL ,
-    OPEN,READ,WRIT,CLOS,PRTF,MALC,MSET,MCMP,MCPY,MMAP,DSYM,BSCH,CLCA,STRT,
-    EXIT
+    OPEN,READ,WRIT,CLOS,PRTF,MALC,MSET,MCMP,MCPY,SCMP,MMAP,DSYM,BSCH,CLCA,
+    STRT,EXIT
 };
 
 // types
@@ -758,6 +758,9 @@ int *codegen(int *jitmem, int *jitmap)
                 case MCPY:
                     tmp = (int) (elf ? plt_func_addr[MCPY - OPEN] : dlsym(0, "memcpy"));
                     break;
+                case SCMP:
+                    tmp = (int) (elf ? plt_func_addr[SCMP - OPEN] : dlsym(0, "strcmp"));
+                    break;
                 case MMAP:
                     tmp = (int) (elf ? plt_func_addr[MMAP - OPEN] : dlsym(0, "mmap"));
                     break;
@@ -1283,6 +1286,7 @@ int elf32(int poolsz, int *main)
     func_names[MSET] = append_strtab(&data, "memset") - dynstr_addr;
     func_names[MCMP] = append_strtab(&data, "memcmp") - dynstr_addr;
     func_names[MCPY] = append_strtab(&data, "memcpy") - dynstr_addr;
+    func_names[SCMP] = append_strtab(&data, "strcmp") - dynstr_addr;
     func_names[MMAP] = append_strtab(&data, "mmap") - dynstr_addr;
     func_names[DSYM] = append_strtab(&data, "dlsym") - dynstr_addr;
     func_names[BSCH] = append_strtab(&data, "bsearch") - dynstr_addr;
@@ -1307,6 +1311,7 @@ int elf32(int poolsz, int *main)
     append_func_sym(&data, func_names[MSET]);
     append_func_sym(&data, func_names[MCMP]);
     append_func_sym(&data, func_names[MCPY]);
+    append_func_sym(&data, func_names[SCMP]);
     append_func_sym(&data, func_names[MMAP]);
     append_func_sym(&data, func_names[DSYM]);
     append_func_sym(&data, func_names[BSCH]);
@@ -1534,12 +1539,12 @@ int main(int argc, char **argv)
           "LI   LC   SI   SC   PSH  "
           "OR   XOR  AND  EQ   NE   LT   GT   LE   GE   "
           "SHL  SHR  ADD  SUB  MUL  "
-          "OPEN READ WRIT CLOS PRTF MALC MSET MCMP MCPY MMAP "
+          "OPEN READ WRIT CLOS PRTF MALC MSET MCMP MCPY SCMP MMAP "
           "DSYM BSCH CLCA STRT EXIT";
 
     p = "break case char default else enum if int return "
         "sizeof struct switch for while "
-        "open read write close printf malloc memset memcmp memcpy mmap "
+        "open read write close printf malloc memset memcmp memcpy strcmp mmap "
         "dlsym bsearch __clear_cache __libc_start_main exit void main";
 
     i = Break;

--- a/amacc.c
+++ b/amacc.c
@@ -732,47 +732,47 @@ int *codegen(int *jitmem, int *jitmap)
             else if (i >= OPEN) {
                 switch (i) {
                 case OPEN:
-                    tmp = (int) (elf ? plt_func_addr[0] : dlsym(0, "open"));
+                    tmp = (int) (elf ? plt_func_addr[OPEN - OPEN] : dlsym(0, "open"));
                     break;
                 case READ:
-                    tmp = (int) (elf ? plt_func_addr[1] : dlsym(0, "read"));
+                    tmp = (int) (elf ? plt_func_addr[READ - OPEN] : dlsym(0, "read"));
                     break;
                 case WRIT:
-                    tmp = (int) (elf ? plt_func_addr[2] : dlsym(0, "write"));
+                    tmp = (int) (elf ? plt_func_addr[WRIT - OPEN] : dlsym(0, "write"));
                     break;
                 case CLOS:
-                    tmp = (int) (elf ? plt_func_addr[3] : dlsym(0, "close"));
+                    tmp = (int) (elf ? plt_func_addr[CLOS - OPEN] : dlsym(0, "close"));
                     break;
                 case PRTF:
-                    tmp = (int) (elf ? plt_func_addr[4] : dlsym(0, "printf"));
+                    tmp = (int) (elf ? plt_func_addr[PRTF - OPEN] : dlsym(0, "printf"));
                     break;
                 case MALC:
-                    tmp = (int) (elf ? plt_func_addr[5] : dlsym(0, "malloc"));
+                    tmp = (int) (elf ? plt_func_addr[MALC - OPEN] : dlsym(0, "malloc"));
                     break;
                 case MSET:
-                    tmp = (int) (elf ? plt_func_addr[6] : dlsym(0, "memset"));
+                    tmp = (int) (elf ? plt_func_addr[MSET - OPEN] : dlsym(0, "memset"));
                     break;
                 case MCMP:
-                    tmp = (int) (elf ? plt_func_addr[7] : dlsym(0, "memcmp"));
+                    tmp = (int) (elf ? plt_func_addr[MCMP - OPEN] : dlsym(0, "memcmp"));
                     break;
                 case MCPY:
-                    tmp = (int) (elf ? plt_func_addr[8] : dlsym(0, "memcpy"));
+                    tmp = (int) (elf ? plt_func_addr[MCPY - OPEN] : dlsym(0, "memcpy"));
                     break;
                 case MMAP:
-                    tmp = (int) (elf ? plt_func_addr[9] : dlsym(0, "mmap"));
+                    tmp = (int) (elf ? plt_func_addr[MMAP - OPEN] : dlsym(0, "mmap"));
                     break;
                 case DSYM:
-                    tmp = (int) (elf ? plt_func_addr[10] : dlsym(0, "dlsym"));
+                    tmp = (int) (elf ? plt_func_addr[DSYM - OPEN] : dlsym(0, "dlsym"));
                     break;
                 case BSCH:
-                    tmp = (int) (elf ? plt_func_addr[11] : dlsym(0, "bsearch"));
+                    tmp = (int) (elf ? plt_func_addr[BSCH - OPEN] : dlsym(0, "bsearch"));
                     break;
                 case STRT:
-                    tmp = (int) (elf ? plt_func_addr[13]
+                    tmp = (int) (elf ? plt_func_addr[STRT - OPEN]
                                      : dlsym(0, "__libc_start_main"));
                     break;
                 case EXIT:
-                    tmp = (int) (elf ? plt_func_addr[14] : dlsym(0, "exit"));
+                    tmp = (int) (elf ? plt_func_addr[EXIT - OPEN] : dlsym(0, "exit"));
                     break;
                 default:
                     printf("unrecognized code %d\n", i);
@@ -1405,7 +1405,7 @@ int elf32(int poolsz, int *main)
     if ((int *) je >= jitmap) die("jitmem too small");
 
     // relocate _start() stub.
-    *((int *)(code + 0x28)) = reloc_bl(plt_func_addr[13] - code_addr - 0x28);
+    *((int *)(code + 0x28)) = reloc_bl(plt_func_addr[STRT - OPEN] - code_addr - 0x28);
     *((int *)(code + 0x44)) =
         reloc_bl(jitmap[((int)main - (int)text) >> 2] - (int)code - 0x44);
 

--- a/runtest.py
+++ b/runtest.py
@@ -6,47 +6,82 @@ import subprocess as sp
 import os
 import sys
 
-qemuCmd = "qemu-arm -L /usr/arm-linux-gnueabihf".split()
-amacc = "./amacc"
-gcc = "arm-linux-gnueabihf-gcc"
-amaccdir = "amaccelf"
-gccdir = "gccelf"
+qemuCmd = 'qemu-arm -L /usr/arm-linux-gnueabihf'.split()
+amacc = './amacc'
+gcc = 'arm-linux-gnueabihf-gcc'
+amaccdir = 'amaccelf'
+gccdir = 'gccelf'
 
 
 class TestAmacc(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+
+        if not os.access(amaccdir, os.F_OK):
+            os.mkdir(amaccdir)
+        if not os.access(gccdir, os.F_OK):
+            os.mkdir(gccdir)
+
+
+class TestAmacc_UC(unittest.TestCase):
+    """ Test cases without -fsigned-char (default) """
     pass
 
 
-def testGenerator(f):
+class TestAmacc_SC(unittest.TestCase):
+    """ Test cases with -fsigned-char """
+    pass
+
+
+def _generate_test(test_name, test_file, extra_cflags):
     def test(self):
-        print("verify file: %s" % (f))
+        args = ['2']
 
-        # amaccexe = os.path.join(amaccdir, os.path.splitext(os.path.basename(f))[0])
-        gccexe = os.path.join(gccdir, os.path.splitext(os.path.basename(f))[0])
-        gccparams = [gcc, "-o", gccexe, f]
-        sp.check_call(gccparams)
+        test_file_name = os.path.splitext(os.path.basename(test_file))[0]
 
-        amaccout = sp.Popen(qemuCmd + [amacc, f, "2"], stdout=sp.PIPE).communicate()[0]
-        gccout = sp.Popen(qemuCmd + [gccexe, "2"], stdout=sp.PIPE).communicate()[0]
+        # compile test program with gcc and run the output executable
+        prog_exe = os.path.join(gccdir, test_file_name)
+        gcc_params = [gcc, '-o', prog_exe, test_file] + extra_cflags
+        sp.check_call(gcc_params)
 
-        self.maxDiff = None
-        self.assertEqual(amaccout.decode("utf-8"), gccout.decode("utf-8"))
+        proc = sp.Popen(qemuCmd + [prog_exe] + args, stdout=sp.PIPE)
+        gcc_out, gcc_err = proc.communicate()
+
+        # run amacc in jit mode
+        amacc_params = [amacc] + extra_cflags + [test_file] + args
+        proc = sp.Popen(qemuCmd + amacc_params, stdout=sp.PIPE)
+        amacc_out, amacc_err = proc.communicate()
+        self.assertEqual(amacc_out.decode('utf-8'), gcc_out.decode('utf-8'))
+
+        # run amacc in compiler mode
+        prog_exe = os.path.join(amaccdir, test_file_name)
+        amacc_params = [amacc] + extra_cflags + ['-o', prog_exe, test_file]
+        sp.check_call(qemuCmd + amacc_params)
+
+        proc = sp.Popen(qemuCmd + [prog_exe] + args, stdout=sp.PIPE)
+        amacc_out, amacc_err = proc.communicate()
+        self.assertEqual(amacc_out.decode('utf-8'), gcc_out.decode('utf-8'))
 
     return test
 
+
+def _define_tests():
+    for dirpath, _, filenames in os.walk('tests'):
+        for f in filenames:
+            test_file = os.path.abspath(os.path.join(dirpath, f))
+            test_name = 'test_%s' % (os.path.splitext(f)[0])
+
+            # test without -fsigned-char (default ABI)
+            test_func = _generate_test(test_name, test_file, [])
+            setattr(TestAmacc_UC, test_name, test_func)
+
+            # test with -fsigned-char
+            test_func = _generate_test(test_name, test_file, ['-fsigned-char'])
+            setattr(TestAmacc_SC, test_name, test_func)
+
+_define_tests()
+
+
 if __name__ == '__main__':
-    if not os.access(amaccdir, os.F_OK):
-        os.mkdir(amaccdir)
-    if not os.access(gccdir, os.F_OK):
-        os.mkdir(gccdir)
-
-    namePattern = ""
-    if len(sys.argv) > 1:
-        namePattern = sys.argv[1]
-
-    for dirpath, _, filenames in os.walk("tests"):
-        for f in filter(lambda name: namePattern in name, filenames):
-            testfile = os.path.abspath(os.path.join(dirpath, f))
-            test_func = testGenerator(testfile)
-            setattr(TestAmacc, 'test_%s' % (os.path.splitext(f)[0]), test_func)
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main()

--- a/tests/cond.c
+++ b/tests/cond.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int main(int argc, char **argv)
 {
     if (argc == 1) {

--- a/tests/eq.c
+++ b/tests/eq.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int main()
 {
     printf("16000 == 16000 : %d\n", 16000 == 16000);

--- a/tests/jit.c
+++ b/tests/jit.c
@@ -1,3 +1,7 @@
+#include <sys/mman.h>
+#include <stdlib.h>
+#include <stdio.h>
+
 int main(int ac, char **av)
 {
     char *jitmem;

--- a/tests/literal.c
+++ b/tests/literal.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int main()
 {
     int a;

--- a/tests/printf.c
+++ b/tests/printf.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+
 int main()
 {
     printf("arg1 %s %s %s %s %s\n", "arg2", "arg3", "arg4", "arg5", "arg6");

--- a/tests/ptr.c
+++ b/tests/ptr.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int main()
 {
   int *s, *e, v;

--- a/tests/read.c
+++ b/tests/read.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 int main(int argc, char **argv)
 {

--- a/tests/shift.c
+++ b/tests/shift.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+
 int main()
 {
     int a, b, c;

--- a/tests/switch.c
+++ b/tests/switch.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int main(int argc, char **argv)
 {
     switch (argc) {
@@ -6,6 +8,6 @@ int main(int argc, char **argv)
     default:
         printf("More than 1 argument\n");
         break;
-    }                                                                                                                       
+    }
     return 0;
 }


### PR DESCRIPTION
These commits add `-fsigned-char` to `amacc` and fix an output difference between the executable generated by `amacc` and the executable generated by `gcc`.

Fix: #23 