### PR TITLE
Fix incorrect usage of modulo ABI

### DIFF
--- a/amacc.c
+++ b/amacc.c
@@ -1407,6 +1407,10 @@ int *codegen(int *jitmem, int *jitmap)
             if (!imm0) imm0 = je;
             *il++ = (int) je++ + 1;
             *iv++ = tmp;
+            // ARM EABI modulo helper function produces quotient in r0
+            // and the remainder in r1.
+            if (i == MOD)
+                *je++ = 0xe1a00001;                 // mov r0, r1
             break;
         case CLCA:
             *je++ = 0xe59d0004; *je++ = 0xe59d1000; // ldr r0, [sp, #4]


### PR DESCRIPTION


Fixed #61 

In AMaCC, we always assume r0 is where the return argument stored,
however, the functions __aeabi_idivmod and __aeabi_uidivmod are
2-value-returning functions.

According to 'Run-time ABI for the ARM Architecture' with version 2.09
and section 4.3.1:
    The division functions take the numerator and denominator
    in that order, and produce the quotient in r0 or the quotient and
    the remainder in {r0, r1} respectively.

Hack the first instruction where the function returns with mov r1 to r0.