### PR TITLE
docs: fix simple typo, statemanet -> statement

### DIFF
--- a/amacc.c
+++ b/amacc.c
@@ -1079,7 +1079,7 @@ void stmt(int ctx)
             next();
             break;
         }
-        /* parse statemanet such as 'int a, b, c;'
+        /* parse statement such as 'int a, b, c;'
          * "enum" finishes by "tk == ';'", so the code below will be skipped.
          * While current token is not statement end or block end.
          */


### PR DESCRIPTION
There is a small typo in amacc.c.

Should read `statement` rather than `statemanet`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md