### PR TITLE
add disasm script. Usage: amacc -o fib tests/fib.c ; scripts/disasm fib

### DIFF
--- a/scripts/disasm
+++ b/scripts/disasm
@@ -1,0 +1,5 @@
+#!/bin/bash
+# disasm <amacc ELF executable file>
+dd bs=1 if=$1 of=$1.asmtmp `readelf -a $1 2>/dev/null | awk '/\.text.*PROGBITS/ { s = sprintf("skip=%d", "0x" $6) ; c = sprintf("count=%d", "0x" $7) ; print s, c }'`
+objdump -b binary -m arm -D $1.asmtmp
+rm $1.asmtmp

--- a/scripts/disasm
+++ b/scripts/disasm
@@ -1,5 +1,8 @@
-#!/bin/bash
-# disasm <amacc ELF executable file>
+#!/usr/bin/env bash
+if [ "$#" != "1" ]; then
+    echo "Usage: disasm <amacc ELF executable file>"
+    exit
+fi
 dd bs=1 if=$1 of=$1.asmtmp `readelf -a $1 2>/dev/null | awk '/\.text.*PROGBITS/ { s = sprintf("skip=%d", "0x" $6) ; c = sprintf("count=%d", "0x" $7) ; print s, c }'`
 objdump -b binary -m arm -D $1.asmtmp
 rm $1.asmtmp

--- a/scripts/disasm
+++ b/scripts/disasm
@@ -3,6 +3,7 @@ if [ "$#" != "1" ]; then
     echo "Usage: disasm <amacc ELF executable file>"
     exit
 fi
-dd bs=1 if=$1 of=$1.asmtmp `readelf -a $1 2>/dev/null | awk '/\.text.*PROGBITS/ { s = sprintf("skip=%d", "0x" $6) ; c = sprintf("count=%d", "0x" $7) ; print s, c }'`
+DD_BYTES=`readelf -a $1 2>/dev/null | awk '/\.text.*PROGBITS/ { s = sprintf("skip=%d", "0x" $6) ; c = sprintf("count=%d", "0x" $7) ; print s, c }'`
+dd bs=1 if=$1 of=$1.asmtmp $DD_BYTES
 objdump -b binary -m arm -D $1.asmtmp
 rm $1.asmtmp


### PR DESCRIPTION
Hack to disassemble amacc executable. Note that there will be pc relative data after some functions, and the disassembler will produce bogus instructions in those regions.  Each function typically begins with the "push {fp, lr}" instructruction and ends with the "pop {fp, pc}" instruction.