### PR TITLE
Fix important bug in  multi-assign declarations

### DIFF
--- a/amacc.c
+++ b/amacc.c
@@ -1281,6 +1281,7 @@ void stmt(int ctx)
          * "enum" finishes by "tk == ';'", so the code below will be skipped.
          * While current token is not statement end or block end.
          */
+        b = 0;
         while (tk != ';' && tk != '}' && tk != ',' && tk != ')') {
             ty = bt;
             // if the beginning of * is a pointer type, then type plus `PTR`
@@ -1299,6 +1300,7 @@ void stmt(int ctx)
             next();
             id->type = ty;
             if (tk == '(') { // function
+                if (b != 0) fatal("func decl can't be mixed with var decl(s)");
                 if (ctx != Glo) fatal("nested function");
                 if (ty > INT && ty < PTR) fatal("return type can't be struct");
                 id->class = Func; // type is function
@@ -1354,9 +1356,11 @@ void stmt(int ctx)
                 }
                 if (ctx == Loc && tk == Assign) {
                     int ptk = tk;
-                    *--n = loc - id->val; *--n = Loc;
+                    if (b == 0) *--n = ';';
+                    b = n; *--n = loc - id->val; *--n = Loc;
                     next(); a = n; expr(ptk);
                     *--n = (int)a; *--n = ty; *--n = Assign;
+                    *--n = (int) b; *--n = '{';
                 }
             }
             if (ctx != Par && tk == ',') next();

--- a/tests/assign.c
+++ b/tests/assign.c
@@ -14,6 +14,11 @@ int main(int argc, char **argv)
 {
     /* Value test */
     int a, b, c;
+    int d = 5, e = 10;
+
+    assert_eq(d, 5);
+    assert_eq(e, 10);
+
     a = 1;
     a += 101;
     assert_eq(a, 102);


### PR DESCRIPTION
int a = 1, b = 2, c = 3; was only doing the last assign before this patch/fix.