### PR TITLE
CI: Update Arm GNU Toolchain and use Ubuntu 24.04

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,0 +1,18 @@
+GCC_REL=14.2.rel1
+ARM_MIRROR=https://github.com/DLTcollab/toolchain-arm/raw/main
+
+SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|h)\$" | egrep -v "arm-gnu-toolchain-${GCC_REL}-x86_64-aarch64-none-linux-gnu|arm-gnu-toolchain-${GCC_REL}-x86_64-arm-none-linux-gnueabihf")
+
+# Expect host is Linux/x86_64
+check_platform()
+{
+    MACHINE_TYPE=`uname -m`
+    if [ ${MACHINE_TYPE} != 'x86_64' ]; then
+        exit
+    fi
+
+    OS_TYPE=`uname -s`
+    if [ ${OS_TYPE} != 'Linux' ]; then
+        exit
+    fi
+}

--- a/.ci/cross-check.sh
+++ b/.ci/cross-check.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 
-MACHINE_TYPE=`uname -m`
-if [ ${MACHINE_TYPE} != 'x86_64' ]; then
-    exit
-fi
+. .ci/common.sh
 
-OS_TYPE=`uname -s`
-if [ ${OS_TYPE} != 'Linux' ]; then
-    exit
-fi
+check_platform
 
 # Clang/LLVM is natively a cross-compiler.
 # TODO: Do cross-compilation using Clang
@@ -17,9 +11,7 @@ if [ $(printenv CXX | grep clang) ]; then
     exit
 fi
 
-GCC_REL=11.2-2022.02
-
 set -x
 
-export PATH=gcc-arm-${GCC_REL}-x86_64-arm-none-linux-gnueabihf/bin:$PATH
+export PATH=arm-gnu-toolchain-${GCC_REL}-x86_64-arm-none-linux-gnueabihf/bin:$PATH
 make CROSS_COMPILE=arm-none-linux-gnueabihf- check || exit 1

--- a/.ci/cross-tool.sh
+++ b/.ci/cross-tool.sh
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
 
-ARM_MIRROR=https://github.com/DLTcollab/toolchain-arm/raw/main
-GCC_REL=11.2-2022.02
+. .ci/common.sh
 
-MACHINE_TYPE=`uname -m`
-if [ ${MACHINE_TYPE} != 'x86_64' ]; then
-    exit
-fi
-
-OS_TYPE=`uname -s`
-if [ ${OS_TYPE} != 'Linux' ]; then
-    exit
-fi
+check_platform
 
 set -x
 
@@ -21,5 +12,5 @@ sudo apt-get install -q -y qemu-user
 sudo apt-get install -y curl xz-utils
 
 curl -L \
-    ${ARM_MIRROR}/gcc-arm-${GCC_REL}-x86_64-arm-none-linux-gnueabihf.tar.xz \
+    ${ARM_MIRROR}/arm-gnu-toolchain-${GCC_REL}-x86_64-arm-none-linux-gnueabihf.tar.xz \
     | tar -Jx || exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,13 +4,13 @@ on: [push, pull_request]
 
 jobs:
   host_x86:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        compiler: [gcc-10]
+        compiler: [gcc]
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: build artifact
         env:
           CC: ${{ matrix.compiler }}


### PR DESCRIPTION
The pre-built GNU compiler toolchain for various Arm targets. Version 14.2.Rel1.